### PR TITLE
ci: fix deprecation warning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: "Get current date"
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: "Login to GitHub Container Registry"
         uses: docker/login-action@v3


### PR DESCRIPTION
set-output is being deprecated, use the new method https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/